### PR TITLE
Add input assign_public_ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Please refer to the [examples](./examples/basic) on how to get started.
 | <a name="input_agent_log_level"></a> [agent\_log\_level](#input\_agent\_log\_level) | The logging verbosity for the agent. Valid values are trace, debug, info (default), warn, and error. | `string` | `"info"` | no |
 | <a name="input_agent_memory"></a> [agent\_memory](#input\_agent\_memory) | The amount of memory, in MB, allocated to the agent container(s). | `number` | `512` | no |
 | <a name="input_agent_single_execution"></a> [agent\_single\_execution](#input\_agent\_single\_execution) | Whether to use single-execution mode. | `bool` | `true` | no |
+| <a name="input_assign_public_ip"></a> [assign\_public\_ip](#input\_assign\_public\_ip) | Whether to assign a public IP address to the ECS tasks. Set to true when using public subnets. | `bool` | `false` | no |
 | <a name="input_cloudwatch_log_group_name"></a> [cloudwatch\_log\_group\_name](#input\_cloudwatch\_log\_group\_name) | The name of the CloudWatch log group where agent logs will be sent. | `string` | `"/hcp/hcp-terraform-agent"` | no |
 | <a name="input_cloudwatch_log_group_retention"></a> [cloudwatch\_log\_group\_retention](#input\_cloudwatch\_log\_group\_retention) | The number of days to retain logs in the CloudWatch log group. | `number` | `365` | no |
 | <a name="input_create_cloudwatch_log_group"></a> [create\_cloudwatch\_log\_group](#input\_create\_cloudwatch\_log\_group) | Whether the CloudWatch log group should be created. | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -162,7 +162,7 @@ resource "aws_ecs_service" "hcp_terraform_agent" {
   }
 
   network_configuration {
-    assign_public_ip = "false"
+    assign_public_ip = var.assign_public_ip
     security_groups  = [aws_security_group.hcp_terraform_agent.id]
     subnets          = var.subnet_ids
   }

--- a/variables.tf
+++ b/variables.tf
@@ -208,3 +208,9 @@ variable "kms_key_arn" {
   type        = string
   default     = ""
 }
+
+variable "assign_public_ip" {
+  type        = bool
+  description = "Whether to assign a public IP address to the ECS tasks. Set to true when using public subnets."
+  default     = false
+}


### PR DESCRIPTION
This input is needed when running the cluster in a public subnet.