### PR TITLE
Add ability to pass extra secrets to agent container

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Please refer to the [examples](./examples/basic) on how to get started.
 | [aws_iam_role_policy.agent_init_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.ssm_access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.ecs_task_execution_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ecs_task_execution_role_policy_attachments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ecs_task_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kms_key.log_ssm_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_security_group.hcp_terraform_agent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -76,9 +77,9 @@ Please refer to the [examples](./examples/basic) on how to get started.
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | IDs of the subnet(s) where agents can be deployed | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC where the cluster is running. | `string` | n/a | yes |
 | <a name="input_agent_auto_update"></a> [agent\_auto\_update](#input\_agent\_auto\_update) | Whether the agent should auto-update. Valid values are minor, patch, and disabled. | `string` | `"minor"` | no |
-| <a name="input_agent_cidr_blocks"></a> [agent\_cidr\_blocks](#input\_agent\_cidr\_blocks) | CIDR blocks to allow the agent to communicate with the HCP Terraform instance. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_agent_cidr_blocks"></a> [agent\_cidr\_blocks](#input\_agent\_cidr\_blocks) | CIDR blocks to allow the agent to communicate with the HCP Terraform instance. | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
 | <a name="input_agent_cpu"></a> [agent\_cpu](#input\_agent\_cpu) | The CPU units allocated to the agent container(s). See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html#fargate-tasks-size | `number` | `256` | no |
-| <a name="input_agent_egress_ports"></a> [agent\_egress\_ports](#input\_agent\_egress\_ports) | Egress ports to allow the agent to communicate with the HCP Terraform instance. | `set(string)` | <pre>[<br>  "443",<br>  "7146"<br>]</pre> | no |
+| <a name="input_agent_egress_ports"></a> [agent\_egress\_ports](#input\_agent\_egress\_ports) | Egress ports to allow the agent to communicate with the HCP Terraform instance. | `set(string)` | <pre>[<br/>  "443",<br/>  "7146"<br/>]</pre> | no |
 | <a name="input_agent_image"></a> [agent\_image](#input\_agent\_image) | The Docker image to launch. | `string` | `"hashicorp/tfc-agent:latest"` | no |
 | <a name="input_agent_log_level"></a> [agent\_log\_level](#input\_agent\_log\_level) | The logging verbosity for the agent. Valid values are trace, debug, info (default), warn, and error. | `string` | `"info"` | no |
 | <a name="input_agent_memory"></a> [agent\_memory](#input\_agent\_memory) | The amount of memory, in MB, allocated to the agent container(s). | `number` | `512` | no |
@@ -90,11 +91,13 @@ Please refer to the [examples](./examples/basic) on how to get started.
 | <a name="input_create_ecs_cluster"></a> [create\_ecs\_cluster](#input\_create\_ecs\_cluster) | Whether to create a new ECS cluster for the agent. | `bool` | `true` | no |
 | <a name="input_create_tfe_agent_pool"></a> [create\_tfe\_agent\_pool](#input\_create\_tfe\_agent\_pool) | Whether to omit agent pool/token creation | `bool` | `true` | no |
 | <a name="input_ecs_cluster_arn"></a> [ecs\_cluster\_arn](#input\_ecs\_cluster\_arn) | ARN of the ECS cluster where the agent will be deployed. | `string` | `"arn:aws:ecs:us-west-2:000000000000:cluster/ecs-basic"` | no |
-| <a name="input_extra_env_vars"></a> [extra\_env\_vars](#input\_extra\_env\_vars) | Extra environment variables to pass to the agent container. | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
+| <a name="input_extra_env_vars"></a> [extra\_env\_vars](#input\_extra\_env\_vars) | Extra environment variables to pass to the agent container. | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_extra_secrets"></a> [extra\_secrets](#input\_extra\_secrets) | Extra secrets to pass to the agent container. | <pre>list(object({<br/>    name      = string<br/>    valueFrom = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_hcp_terraform_address"></a> [hcp\_terraform\_address](#input\_hcp\_terraform\_address) | The HTTPS address of the HCP Terraform or HCP Terraform Enterprise instance. | `string` | `"https://app.terraform.io"` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the KMS key to create. If empty, a new key will be created. | `string` | `""` | no |
 | <a name="input_num_agents"></a> [num\_agents](#input\_num\_agents) | The number of agent containers to run. | `number` | `1` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to apply to resources deployed by this solution. | `map(any)` | `null` | no |
+| <a name="input_task_execution_policy_arns"></a> [task\_execution\_policy\_arns](#input\_task\_execution\_policy\_arns) | ARN(s) of IAM policies to attach to the agent task execution role. | `list(string)` | `[]` | no |
 | <a name="input_task_policy_arns"></a> [task\_policy\_arns](#input\_task\_policy\_arns) | ARN(s) of IAM policies to attach to the agent task. Determines what actions the agent can take without requiring additional AWS credentials. | `list(string)` | `[]` | no |
 | <a name="input_tfe_agent_pool_name"></a> [tfe\_agent\_pool\_name](#input\_tfe\_agent\_pool\_name) | Terraform agent pool name to be used when agent creation is omitted | `string` | `""` | no |
 | <a name="input_tfe_agent_token"></a> [tfe\_agent\_token](#input\_tfe\_agent\_token) | Terraform agent token to be used when agent creation is omitted | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -133,12 +133,12 @@ resource "aws_ecs_task_definition" "hcp_terraform_agent" {
             value = var.agent_auto_update
           }
         ], var.extra_env_vars),
-        secrets = [
+        secrets = concat([
           {
             name      = "TFC_AGENT_TOKEN",
             valueFrom = aws_ssm_parameter.agent_token.arn
           }
-        ]
+        ], var.extra_secrets)
       }
     ]
   )
@@ -297,6 +297,13 @@ resource "aws_iam_role_policy" "agent_init_policy" {
   role   = aws_iam_role.ecs_task_execution_role.name
   name   = "AccessSSMforAgentToken"
   policy = data.aws_iam_policy_document.agent_init_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy_attachments" {
+  for_each = toset(var.task_execution_policy_arns)
+
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = each.key
 }
 
 resource "aws_iam_role" "ecs_task_role" {

--- a/variables.tf
+++ b/variables.tf
@@ -122,6 +122,15 @@ variable "extra_env_vars" {
   default     = []
 }
 
+variable "extra_secrets" {
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  description = "Extra secrets to pass to the agent container."
+  default     = []
+}
+
 variable "num_agents" {
   type        = number
   description = "The number of agent containers to run."
@@ -202,6 +211,11 @@ variable "task_policy_arns" {
   default     = []
 }
 
+variable "task_execution_policy_arns" {
+  type        = list(string)
+  description = "ARN(s) of IAM policies to attach to the agent task execution role."
+  default     = []
+}
 
 variable "kms_key_arn" {
   description = "The ARN of the KMS key to create. If empty, a new key will be created."


### PR DESCRIPTION
This PR adds ability to pass extra secrets to HCP agent and additional policies to attach to ECS task execution role.