### PR TITLE
feat: Bump ecs module to v6.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Please refer to the [examples](./examples/basic) on how to get started.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | git::https://github.com/terraform-aws-modules/terraform-aws-ecs | 6b52c965734d95767d8e20d965afcd0db29dae5e |
+| <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | git::https://github.com/terraform-aws-modules/terraform-aws-ecs | be968fc4af733fae2ac41dfb3c34dce7712e028f |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -209,20 +209,16 @@ resource "aws_security_group_rule" "allow_egress" {
 
 module "ecs_cluster" {
   count  = var.create_ecs_cluster ? 1 : 0
-  source = "git::https://github.com/terraform-aws-modules/terraform-aws-ecs?ref=6b52c965734d95767d8e20d965afcd0db29dae5e" # v5.11.2
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-ecs?ref=be968fc4af733fae2ac41dfb3c34dce7712e028f" # v6.6.1
 
   cluster_name = var.name
 
-  fargate_capacity_providers = {
+  default_capacity_provider_strategy = {
     FARGATE = {
-      default_capacity_provider_strategy = {
-        weight = 50
-      }
+      weight = 50
     }
     FARGATE_SPOT = {
-      default_capacity_provider_strategy = {
-        weight = 50
-      }
+      weight = 50
     }
   }
 


### PR DESCRIPTION
Bumping [terraform-aws-modules/ecs/aws](https://registry.terraform.io/modules/terraform-aws-modules/ecs/aws/latest) module from version 5.11.2 to version 6.6.1 to support hashicorp/aws provider >= 6.0.0.

Due to deprecation of the `inference_accelerator` attribute in `aws_ecs_task_definiton` resources the module  was failing with newer providers.

Module input adjusted to fix deprecation of `fargate_capacity_providers` input variable in [version 6.0.0](https://github.com/terraform-aws-modules/terraform-aws-ecs/releases/tag/v6.0.0) of terraform-aws-modules/ecs/aws.

Fixes #39 